### PR TITLE
Fix `contextlib.chdir` only available on Python 3.11 and newer. Enable CI testing on Python 3.10.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.10", "3.11"]
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/ngr.yml
+++ b/.github/workflows/ngr.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.10", "3.11"]
 
     env:
       OS: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes for pueblo
 
 ## Unreleased
+- ngr: Fix `contextlib.chdir` only available on Python 3.11 and newer
 
 ## 2023-11-01 v0.0.2
 - ngr: Use Makefile runner as fallback

--- a/pueblo/ngr/runner.py
+++ b/pueblo/ngr/runner.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 import shlex
 import shutil
@@ -10,6 +9,12 @@ from pathlib import Path
 
 from pueblo.ngr.model import ItemType
 from pueblo.ngr.util import is_venv, mp, run_command
+
+try:
+    from contextlib import chdir as chdir_ctx  # type: ignore[attr-defined,unused-ignore]
+except ImportError:
+    from contextlib_chdir import chdir as chdir_ctx  # type: ignore[no-redef,unused-ignore]
+
 
 logger = logging.getLogger()
 
@@ -28,7 +33,7 @@ class RunnerBase:
         # Change working directory to designated path.
         # From there, address paths relatively.
 
-        with contextlib.chdir(self.path):
+        with chdir_ctx(self.path):
             self.path = Path(".")
 
             logger.info("Environment Information")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ develop = [
   "black<24",
   "mypy==1.6.1",
   "poethepoet<1",
-  "pyproject-fmt>=1.3,<1.5",
+  "pyproject-fmt<1.5,>=1.3",
   "ruff==0.1.4",
   "validate-pyproject<0.16",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dynamic = [
 ]
 
 dependencies = [
+  'contextlib-chdir; python_version < "3.11"',
   'importlib-metadata; python_version <= "3.7"',
   "platformdirs<4",
 ]

--- a/tests/test_ngr.py
+++ b/tests/test_ngr.py
@@ -52,3 +52,18 @@ def test_ngr_sample(sample: Path):
         prog_name=PROGRAM_NAME,
     )
     assert result.exit_code == 0
+
+
+def test_ngr_make():
+    """
+    Invoke minimal `ngr test` target.
+    """
+    runner = CliRunner()
+
+    result = runner.invoke(
+        pueblo.ngr.cli,
+        args="test --accept-no-venv tests/ngr/make",
+        catch_exceptions=False,
+        prog_name=PROGRAM_NAME,
+    )
+    assert result.exit_code == 0

--- a/tests/test_nlp.py
+++ b/tests/test_nlp.py
@@ -1,7 +1,6 @@
-from pueblo.nlp.resource import CachedWebResource
-
-
 def test_cached_web_resource():
+    from pueblo.nlp.resource import CachedWebResource
+
     url = "https://github.com/langchain-ai/langchain/raw/v0.0.325/docs/docs/modules/state_of_the_union.txt"
     docs = CachedWebResource(url).langchain_documents(chunk_size=1000, chunk_overlap=0)
     assert len(docs) == 42


### PR DESCRIPTION
## Problem

`contextlib.chdir` is only available on Python 3.11 and newer.

## Solution

- Use [`contextlib-chdir`](https://pypi.org/project/contextlib-chdir/) package on Python < 3.11.
- Enable software testing on CI, also with Python 3.10.

