### PR TITLE
Fix dependencies for `test` extra by downgrading to `nbdime<4`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add a few testing helper utilities to `pueblo.testing`
+- Fix dependencies for `test` extra by downgrading to `nbdime<4`
  
 ## 2023-11-06 v0.0.3
 - ngr: Fix `contextlib.chdir` only available on Python 3.11 and newer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ release = [
 ]
 test = [
   "nbclient<0.10",
+  "nbdime<4",
   "pytest<8",
   "pytest-cov<5",
   "pytest-mock<4",


### PR DESCRIPTION
## Problem

Both PRs bei Dependabot showed that something went south.

- GH-21
- GH-22

## Analysis

We discovered that it was about the `nbdime` package, apparently breaking a little detail with its 4.x release.

-- https://pypi.org/project/nbdime/#history
