### PR TITLE
ngr: Fix Gradle test runner by removing invocation of `install` target

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 - Add a few testing helper utilities to `pueblo.testing`
 - Fix dependencies for `test` extra by downgrading to `nbdime<4`
 - Dependencies (extras): Remove "ngr", add "notebook", link "test" to "testing"
+- ngr: Gradle test runner failed to invoke `./gradlew install` because such a
+  target did not exist.
  
 ## 2023-11-06 v0.0.3
 - ngr: Fix `contextlib.chdir` only available on Python 3.11 and newer

--- a/pueblo/ngr/runner.py
+++ b/pueblo/ngr/runner.py
@@ -237,7 +237,6 @@ class JavaRunner(RunnerBase):
         elif self.has_gradle_files:
             if shutil.which("gradle"):
                 run_command("gradle wrapper")
-            run_command("./gradlew install")
         else:
             raise NotImplementedError("Unable to invoke target: install")
 


### PR DESCRIPTION
## Problem

The Gradle test runner failed to invoke `./gradlew install`, because such a target did not exist.

## References

- GH-24
- https://github.com/crate/crate-sample-apps/tree/main/java-spring

## Solution

Remove invoking the `install` target and see if we can get along without.
