### PR TITLE
ngr: Add capability to invoke projects using the `poethepoet` task runner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - ngr: Gradle test runner failed to invoke `./gradlew install` because such a
   target did not exist.
 - ngr: Fix Gradle test runner by only conditionally invoking `gradle wrapper`
+- ngr: Add capability to invoke projects using the `poethepoet` task runner
  
 ## 2023-11-06 v0.0.3
 - ngr: Fix `contextlib.chdir` only available on Python 3.11 and newer

--- a/tests/ngr/python-poethepoet/pyproject.toml
+++ b/tests/ngr/python-poethepoet/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "ngr-python-test-poethepoet"
+version = "0.0.1"
+
+dependencies = [
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest<8",
+  "poethepoet<0.25",
+]
+
+[tool.poe.tasks]
+test = [
+  { cmd="python -c \"print('Hallo, Räuber Hotzenplotz.')\"" },
+]


### PR DESCRIPTION
### Introduction

[poethepoet](https://pypi.org/project/poethepoet/) is a popular task runner amongst Python folks. It is sweet, because you can inline the task definitions into your `pyproject.toml` file you are maintaining anyway.

### About

To improve the `ngr` subsystem a bit further, this patch adds the capability to invoke tests on projects using poethepoet, aka. `poe`. The sweet thing here is that we can introspect the task definitions programmatically, and choose from whether to invoke the `check` or `test` target heuristically.

### Details

`ngr` will prefer to invoke `poe check`, aiming to resemble the same semantics what `./gradlew check` offers, bundling linter/checkstyle **and** software test targets into a single invocation entrypoint [^1]. We established this convention on a number of Python projects already, and `ngr test` follows that convention now.

### References

This improvement has been seeded from a real project, where it is already used and verified on.

- https://github.com/crate/crate-sample-apps/pull/164/commits/8d56fd5f8e0662
- https://github.com/crate/crate-sample-apps/pull/164

/cc @nat-n

[^1]: Effectively, `poe check` just invokes `poe lint` and `poe test`, but that is an implementation detail from the perspective of `ngr`.
