### PR TITLE
ngr: Make .NET runner accept `--dotnet-version` command-line option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 - ngr: Add capability to invoke projects using the `poethepoet` task runner
 - Dependencies: Update to nbdime 4 and pytest-notebook 0.10
 - Add `pueblo.io.to_io` utility function
+- ngr: Improve .NET runner by accepting `--dotnet-version` command-line option
  
 ## 2023-11-06 v0.0.3
 - ngr: Fix `contextlib.chdir` only available on Python 3.11 and newer

--- a/pueblo/ngr/cli.py
+++ b/pueblo/ngr/cli.py
@@ -27,6 +27,7 @@ def read_command_line_arguments(args=None, prog_name=None):
     test = subparsers.add_parser("test", help="Invoke test suites")
     test.add_argument("target")
     test.add_argument("--accept-no-venv", action="store_true", help="Whether to accept not running in venv")
+    test.add_argument("--dotnet-version", type=str, help=".NET version, like `net6.0`, `net7.0`, or `5.0.x`, `6.0.x`")
     test.add_argument("--npgsql-version", type=str, help="Version of Npgsql")
 
     return parser, parser.parse_args(args=args)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,4 +1,7 @@
+# ruff: noqa: E402
 import pytest
+
+pytest.importorskip("pathlibfs")
 from pathlibfs import Path as PathPlus
 
 from pueblo.io import to_io


### PR DESCRIPTION
## About

The .NET test runner needs to obtain the designated .NET version as a test matrix configuration variable. Otherwise, it will always use the newest .NET framework version, as returned by `dotnet --version`.

## References

- https://github.com/crate/cratedb-examples/issues/172
