### PR TITLE
ngr: Fix Gradle test runner by wiping existing Gradle wrappers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 - Dependencies: Update to nbdime 4 and pytest-notebook 0.10
 - Add `pueblo.io.to_io` utility function
 - ngr: Improve .NET runner by accepting `--dotnet-version` command-line option
+- ngr: Fix Gradle test runner by wiping existing Gradle wrappers, to accommodate
+  for contemporary versions of Java
  
 ## 2023-11-06 v0.0.3
 - ngr: Fix `contextlib.chdir` only available on Python 3.11 and newer


### PR DESCRIPTION
## About

Fixing ngr's Gradle outlet once more aims to accommodate for contemporary versions of Java, where older versions of shipped Gradle wrappers would fail on: `Unsupported class file major version 65` and friends.

Coming from GH-37, this patch attempts to resolve the problem by trying another heuristic, which will prefer wiping an existing `gradlew` wrapper script, if there is a chance that a new one can be generated, i.e. when the `gradle` program is installed on the system.

Otherwise, ngr will emit a corresponding error message:
```
ERROR   : No Gradle wrapper found, and no one could be generated. Consider installing `gradle`.
```

## Testdrive
- https://github.com/crate/cratedb-examples/pull/179