### PR TITLE
Update to pytest-notebook 0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ notebook = [
   "nbclient<0.10",
   "nbdime<5",
   "notebook<8",
-  "pytest-notebook<0.11",
+  "pytest-notebook<0.11,>=0.10",
   "testbook<0.5",
 ]
 proc = [


### PR DESCRIPTION
## Problem

This other CI job [^1] installs `pytest-notebook-0.6.0`. I don't know why. Let's explicitly bump the lower version bound.

[^1]: https://github.com/crate/cratedb-examples/actions/runs/7133587964/job/19426594910?pr=189#step:6:702
