### PR TITLE
Testing: Add `makeTimeDataFrame` and `makeMixedDataFrame` to `pueblo.testing.pandas`

### DIFF
--- a/.github/workflows/ngr.yml
+++ b/.github/workflows/ngr.yml
@@ -8,12 +8,14 @@ on:
     - '.github/workflows/ngr.yml'
     - 'pueblo/ngr/**'
     - 'tests/ngr/**'
+    - 'pyproject.toml'
   push:
     branches: [ main ]
     paths:
     - '.github/workflows/ngr.yml'
     - 'pueblo/ngr/**'
     - 'tests/ngr/**'
+    - 'pyproject.toml'
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes for pueblo
 
 ## Unreleased
+- Testing: Add `pueblo.testing.pandas.makeTimeDataFrame`, it was removed
+  from `pandas._testing` on behalf of pandas 2.2.0.
 
 ## 2024-01-19 v0.0.6
 - Packaging: Fix `MANIFEST.in`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Changes for pueblo
 
 ## Unreleased
-- Testing: Add `pueblo.testing.pandas.makeTimeDataFrame`, it was removed
-  from `pandas._testing` on behalf of pandas 2.2.0.
+- Testing: Add `pueblo.testing.pandas.{makeTimeDataFrame,makeMixedDataFrame}`.
+  They have been removed from `pandas._testing` on behalf of pandas 2.2.0.
 
 ## 2024-01-19 v0.0.6
 - Packaging: Fix `MANIFEST.in`

--- a/pueblo/testing/dataframe.py
+++ b/pueblo/testing/dataframe.py
@@ -5,8 +5,9 @@ from collections import OrderedDict
 from inspect import signature
 
 import pandas as pd
-from pandas._testing import makeMixedDataFrame, makeTimeDataFrame
 from pandas.io.formats.info import DataFrameInfo
+
+from pueblo.testing.pandas import makeMixedDataFrame, makeTimeDataFrame
 
 logger = logging.getLogger(__name__)
 

--- a/pueblo/testing/pandas.py
+++ b/pueblo/testing/pandas.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+
+def makeTimeDataFrame(nper=None, freq="B") -> pd.DataFrame:
+    """
+    pandas 2.2.0 removed `pandas._testing.makeTimeDataFrame`.
+
+    TST/CLN: Remove makeTime methods
+    https://github.com/pandas-dev/pandas/pull/56264
+
+    :param nper:
+    :param freq:
+    :return:
+    """
+    return pd.DataFrame(
+        np.random.default_rng(2).standard_normal((nper, 4)),
+        columns=pd.Index(list("ABCD"), dtype=object),
+        index=pd.date_range("2000-01-01", periods=nper, freq=freq),
+    )

--- a/pueblo/testing/pandas.py
+++ b/pueblo/testing/pandas.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import numpy as np
 import pandas as pd
 
@@ -18,3 +20,20 @@ def makeTimeDataFrame(nper=None, freq="B") -> pd.DataFrame:
         columns=pd.Index(list("ABCD"), dtype=object),
         index=pd.date_range("2000-01-01", periods=nper, freq=freq),
     )
+
+
+def getMixedTypeDict() -> t.Tuple[pd.Index, t.Dict[str, t.Any]]:
+    index = pd.Index(["a", "b", "c", "d", "e"])
+
+    data = {
+        "A": [0.0, 1.0, 2.0, 3.0, 4.0],
+        "B": [0.0, 1.0, 0.0, 1.0, 0.0],
+        "C": ["foo1", "foo2", "foo3", "foo4", "foo5"],
+        "D": pd.bdate_range("1/1/2009", periods=5),
+    }
+
+    return index, data
+
+
+def makeMixedDataFrame() -> pd.DataFrame:
+    return pd.DataFrame(getMixedTypeDict()[1])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dataframe = [
   "dask",
   "numpy",
   "pandas",
+  "pyarrow",
 ]
 develop = [
   "black[jupyter]<24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,7 +258,7 @@ format = [
   # Configure Ruff not to auto-fix (remove!):
   # Ignore unused imports (F401), unused variables (F841), `print` statements (T201), and commented-out code (ERA001).
   { cmd = "ruff --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001 ." },
-  { cmd = "pyproject-fmt pyproject.toml" },
+  { cmd = "pyproject-fmt --keep-full-version pyproject.toml" },
 ]
 
 lint = [


### PR DESCRIPTION
## About
`pandas._testing.{makeTimeDataFrame,makeMixedDataFrame}` were removed on behalf of pandas 2.2.0. This patch vendorizes them, to provide polyfills to downstream projects which need them.

## References

### Upstream
- https://github.com/pandas-dev/pandas/pull/56202
- https://github.com/pandas-dev/pandas/pull/56264

### Downstream
The routines are used within test harnesses of those downstream projects, where corresponding updates to pandas 2.2.0 are tripping CI.
- https://github.com/crate/crate-python/pull/607
- https://github.com/crate-workbench/sqlalchemy-cratedb/pull/31
- https://github.com/crate/cratedb-examples/pull/236
- https://github.com/crate/cratedb-examples/pull/240
- https://github.com/daq-tools/influxio/pull/69
