### PR TITLE
ngr: Add capability to invoke Python's built-in `unittest`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes for pueblo
 
 ## Unreleased
+- ngr: Add capability to invoke Python's built-in `unittest`
 
 ## 2024-01-30 v0.0.7
 - Testing: Add `pueblo.testing.pandas.{makeTimeDataFrame,makeMixedDataFrame}`.

--- a/pueblo/ngr/runner.py
+++ b/pueblo/ngr/runner.py
@@ -453,9 +453,14 @@ class PythonRunner(RunnerBase):
         self.has_requirements_txt = mp(self.path, "requirements*.txt")
         self.is_pipx_installed = shutil.which("pipx")
         self.is_poetry_installed = shutil.which("poetry")
+        self.has_ngr_type_file = mp(self.path, ".ngr-type")
 
         if self.has_python_files or self.has_setup_py or self.has_pyproject_toml or self.has_requirements_txt:
             self.type = ItemType.PYTHON
+
+        self.ngr_type: t.Union[str, None] = None
+        if self.has_ngr_type_file:
+            self.ngr_type = (self.path / ".ngr-type").read_text().strip()
 
     def run(self) -> None:
         # Sanity check. When invoking a Python thing within a sandbox,
@@ -547,6 +552,9 @@ class PythonRunner(RunnerBase):
                         break
                 if not success:
                     raise RuntimeError(f"Failed to discover poe task from candidates: {candidates}")
+
+            elif self.ngr_type == "python-unittest":
+                run_command("python -m unittest -vvv")
 
             elif has_pytest:
                 run_command("pytest")

--- a/tests/ngr/python-unittest/.ngr-type
+++ b/tests/ngr/python-unittest/.ngr-type
@@ -1,0 +1,1 @@
+python-unittest

--- a/tests/ngr/python-unittest/test_basic.py
+++ b/tests/ngr/python-unittest/test_basic.py
@@ -1,0 +1,10 @@
+import unittest
+
+
+class ExampleTest(unittest.TestCase):
+    """
+    Verify `ngr test` invokes `python -m unittest` when instructed to.
+    """
+
+    def test_foobar(self):
+        assert 42 == 42


### PR DESCRIPTION
## About
Invoking test suites using `python -m unittest` is needed elsewhere.
- https://github.com/crate/cratedb-examples/pull/280

## How To
It works by signalling it through a file called `.ngr-type` within the folder under test.
```
echo "python-unittest" > .ngr-type
```
