### PR TITLE
CI: Use `uv` package manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,15 +47,18 @@ jobs:
         cache: 'pip'
         cache-dependency-path: 'pyproject.toml'
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v3
+
     - name: Set up project
       run: |
 
         # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
         # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
-        pip install --upgrade 'setuptools>=64'
+        uv pip install --system --upgrade 'setuptools>=64'
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable='.[all,develop,test]'
+        uv pip install --system --upgrade --editable='.[all,develop,test]'
 
     - name: Run linter and software tests
       run: |

--- a/.github/workflows/ngr.yml
+++ b/.github/workflows/ngr.yml
@@ -58,6 +58,9 @@ jobs:
         cache: 'pip'
         cache-dependency-path: 'pyproject.toml'
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v3
+
     # Needed for `pueblo.ngr`.
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
@@ -90,10 +93,10 @@ jobs:
 
         # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
         # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
-        pip install --upgrade 'setuptools>=64'
+        uv pip install --system --upgrade 'setuptools>=64'
 
         # Install package in editable mode.
-        pip install --use-pep517 --prefer-binary --editable='.[cli,develop,test]'
+        uv pip install --system --upgrade --editable='.[cli,develop,test]'
 
     - name: Run linter and software tests
       run: |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ## Setup
 
 ```shell
-pip install --upgrade pueblo
+uv pip install --upgrade pueblo
 ```
 
 After installation, you can verify if it was successful.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ optional-dependencies.fileio = [
 ]
 optional-dependencies.nlp = [
   "aiohttp<3.11",
-  "langchain<0.4",
+  "langchain>=0.1,<0.4",
   "langchain-text-splitters<0.4",
   "unstructured<0.17",
 ]


### PR DESCRIPTION
What the title says. Use [uv](https://docs.astral.sh/uv/) for installing packages instead of vanilla `pip`, for evaluation purposes.