### PR TITLE
Testing: Unlock compatibility with pytest version 8

### DIFF
--- a/.github/workflows/snippet.yml
+++ b/.github/workflows/snippet.yml
@@ -1,0 +1,80 @@
+# pytest-notebook currently needs pytest8
+---
+name: Tests for pueblo.testing.snippet
+
+on:
+  pull_request: ~
+  push:
+    branches: [ main ]
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+  # Run job each night.
+  schedule:
+    - cron: '0 3 * * *'
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  tests:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: [
+          "3.8",
+          "3.13",
+        ]
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
+    steps:
+
+    - name: Acquire sources
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+        cache: 'pip'
+        cache-dependency-path: 'pyproject.toml'
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Set up project
+      run: |
+
+        # `setuptools 0.64.0` adds support for editable install hooks (PEP 660).
+        # https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6400
+        uv pip install --system --upgrade 'setuptools>=64'
+
+        # Install package in editable mode.
+        uv pip install --system --upgrade --editable='.[all,develop,test,testing-pytest7]'
+
+    - name: Run linter and software tests
+      run: |
+        pytest -m pytest_notebook
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        files: ./coverage.xml
+        flags: pytest-notebook
+        env_vars: OS,PYTHON
+        name: codecov-umbrella
+        fail_ci_if_error: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - ngr: For invoking Elixir, use `mix test --trace`
+- Testing: Unlocked compatibility with pytest version 8
 
 ## 2024-10-03 v0.0.10
 - nlp: Updated dependencies langchain, langchain-text-splitters, unstructured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,6 @@ optional-dependencies.notebook = [
   "nbclient<0.11",
   "nbdime<5",
   "notebook<8",
-  "pytest-notebook>=0.10,<0.11",
-  "testbook<0.5",
 ]
 optional-dependencies.proc = [
   "psutil<7",
@@ -120,10 +118,15 @@ optional-dependencies.test = [
 ]
 optional-dependencies.testing = [
   "coverage~=7.3",
-  "pytest<8",
+  "pytest<9",
   "pytest-cov<7",
   "pytest-env<2",
   "pytest-mock<4",
+  "testbook<0.5",
+]
+optional-dependencies.testing-pytest7 = [
+  "pytest<8",
+  "pytest-notebook>=0.10,<0.11",
 ]
 optional-dependencies.web = [
   "requests-cache<2",
@@ -198,7 +201,7 @@ skip_gitignore = false
 [tool.pytest.ini_options]
 minversion = "2.0"
 addopts = """
-  -rfEX -p pytester --strict-markers --verbosity=3
+  -rfEXs -p pytester --strict-markers --verbosity=3
   --cov=pueblo --cov-report=term-missing --cov-report=xml
   --ignore=tests/ngr
   """
@@ -208,6 +211,7 @@ testpaths = [ "tests" ]
 xfail_strict = true
 markers = [
   "ngr",
+  "pytest_notebook",
 ]
 env = [
   "PYDEVD_DISABLE_FILE_VALIDATION=1",

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 
+import _pytest
+import pytest
+
 HERE = Path(__file__).parent
 TESTDATA_FOLDER = HERE / "testdata" / "folder"
 TESTDATA_SNIPPET = HERE / "testdata" / "snippet"
 
 
+@pytest.mark.pytest_notebook
+@pytest.mark.skipif(_pytest.version_tuple >= (8, 0, 0), reason="Requires pytest version 7")
 def test_monkeypatch_pytest_notebook_treat_cell_exit_as_notebook_skip():
     """
     Verify loading a monkeypatch supporting Jupyter Notebook testing.
@@ -30,6 +35,8 @@ def test_pytest_module_function(request, capsys):
     assert out == "Hallo, Räuber Hotzenplotz.\n"
 
 
+@pytest.mark.pytest_notebook
+@pytest.mark.skipif(_pytest.version_tuple >= (8, 0, 0), reason="Requires pytest version 7")
 def test_pytest_notebook(request):
     """
     Verify executing code cells in an arbitrary Jupyter Notebook.


### PR DESCRIPTION
## About
pytest-notebook is not compatible with pytest 8 yet. However, pueblo should not block installing it.

## References
- GH-63
