### PR TITLE
Chore: Naming package extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ optional-dependencies.notebook = [
   "nbclient<0.11",
   "nbdime<5",
   "notebook<8",
+  "testbook<0.5",
 ]
 optional-dependencies.proc = [
   "psutil<7",
@@ -122,7 +123,6 @@ optional-dependencies.testing = [
   "pytest-cov<7",
   "pytest-env<2",
   "pytest-mock<4",
-  "testbook<0.5",
 ]
 optional-dependencies.testing-pytest7 = [
   "pytest<8",


### PR DESCRIPTION
Let `testbook` be part of the `notebook` extra again.