### PR TITLE
ngr: Stopped overwriting existing Gradle wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes for pueblo
 
 ## Unreleased
+- ngr: Stopped overwriting existing Gradle wrapper. The `--gradle-wrapper`
+  option can be used to optionally regenerate the Gradle wrapper now.
 
 ## 2025-01-19 v0.0.11
 - ngr: For invoking Elixir, use `mix test --trace`

--- a/pueblo/ngr/cli.py
+++ b/pueblo/ngr/cli.py
@@ -18,6 +18,7 @@ class NGRRunner(MiniRunner):
         test.add_argument(
             "--dotnet-version", type=str, help=".NET version, like `net6.0`, `net7.0`, or `5.0.x`, `6.0.x`"
         )
+        test.add_argument("--gradle-wrapper", action="store_true", help="Regenerate Gradle wrapper")
         test.add_argument("--npgsql-version", type=str, help="Version of Npgsql")
 
     def run(self):


### PR DESCRIPTION
The `--gradle-wrapper` option can be used to optionally regenerate the Gradle wrapper now.
Other than this, it will be attempted to be generated when none is found.