### PR TITLE
ngr: Deprecated Python's `--accept-no-venv` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - ngr: Stopped overwriting existing Gradle wrapper. The `--gradle-wrapper`
   option can be used to optionally regenerate the Gradle wrapper now.
+- ngr: Deprecated Python's `--accept-no-venv` option: The test runner
+  should not apply any governance here.
 
 ## 2025-01-19 v0.0.11
 - ngr: For invoking Elixir, use `mix test --trace`

--- a/pueblo/ngr/cli.py
+++ b/pueblo/ngr/cli.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import warnings
 
 from pueblo.ngr.core import run
 from pueblo.util.program import MiniRunner
@@ -26,6 +27,9 @@ class NGRRunner(MiniRunner):
             logger.error("Unable to invoke target: Not given or empty")
             self.parser.print_help()
             sys.exit(1)
+
+        if self.args.accept_no_venv:
+            warnings.warn("The `--accept-no-venv` option is deprecated and will be ignored.", stacklevel=2)
 
         try:
             run(self.args.target, self.args.__dict__)

--- a/pueblo/ngr/runner.py
+++ b/pueblo/ngr/runner.py
@@ -2,13 +2,12 @@ import logging
 import shlex
 import shutil
 import subprocess
-import sys
 import typing as t
 from abc import abstractmethod
 from pathlib import Path
 
 from pueblo.ngr.model import ItemType
-from pueblo.ngr.util import is_venv, mp, run_command
+from pueblo.ngr.util import mp, run_command
 
 try:
     from contextlib import chdir as chdir_ctx  # type: ignore[attr-defined,unused-ignore]
@@ -475,16 +474,6 @@ class PythonRunner(RunnerBase):
         self.ngr_type: t.Union[str, None] = None
         if self.has_ngr_type_file:
             self.ngr_type = (self.path / ".ngr-type").read_text().strip()
-
-    def run(self) -> None:
-        # Sanity check. When invoking a Python thing within a sandbox,
-        # don't install system-wide.
-        if not is_venv():
-            if not self.options.get("accept_no_venv", False):
-                logger.error("Unable invoke target without virtualenv. Use `--accept-no-venv` to override.")
-                sys.exit(1)
-
-        return super().run()
 
     def install(self) -> None:
         """


### PR DESCRIPTION
The test runner should not apply any governance here.