### PR TITLE
ngr: Fix `test_ngr_sample[ngr/java-gradle-nowrapper]` example for Gradle 9

### DIFF
--- a/tests/ngr/java-gradle-nowrapper/build.gradle
+++ b/tests/ngr/java-gradle-nowrapper/build.gradle
@@ -39,5 +39,4 @@ application {
 check {
 }
 
-processResources.destinationDir = compileJava.destinationDir
 compileJava.dependsOn processResources


### PR DESCRIPTION
## About
What the title says.

## Details
An aftermath to GH-184. A better GH-178.