### PR TITLE
ngr: Fix .NET/C# test

### DIFF
--- a/tests/ngr/dotnet-csharp/demo.csproj
+++ b/tests/ngr/dotnet-csharp/demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net48;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateProgramFile>false</GenerateProgramFile>


### PR DESCRIPTION
## Problem

The CI workflow started failing after recent updates.
```
warning: NETSDK1138: The target framework 'net7.0' [and lower] is out of support and will not receive security updates in the future.
```