### PR TITLE
Testing: Migrate from pytest's `LocalPath` to `pathlib.Path`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - nlp: Switched from `langchain` to `langchain-core`
+- Testing: Migrated from pytest's `LocalPath` to `pathlib.Path`
 
 ## 2025-11-05 v0.0.12
 - ngr: Stopped overwriting existing Gradle wrapper. The `--gradle-wrapper`

--- a/pueblo/testing/snippet.py
+++ b/pueblo/testing/snippet.py
@@ -42,10 +42,10 @@ def pytest_notebook(request: pytest.FixtureRequest, filepath: t.Union[str, Path]
 
     Not using `NBRegressionFixture`, because it would manually need to be configured.
     """
-    from _pytest._py.path import LocalPath
     from pytest_notebook.plugin import pytest_collect_file
 
-    tests = pytest_collect_file(LocalPath(filepath), request.node)
+    path = Path(filepath)
+    tests = pytest_collect_file(path, request.node)
     if not tests:
         raise ValueError(f"No tests collected from notebook: {filepath}")
     infos = []

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -41,13 +41,12 @@ def test_pytest_notebook(request):
     """
     Verify executing code cells in an arbitrary Jupyter Notebook.
     """
-    from _pytest._py.path import LocalPath
 
     from pueblo.testing.snippet import pytest_notebook
 
     outcomes = pytest_notebook(request=request, filepath=TESTDATA_FOLDER / "dummy.ipynb")
-    assert isinstance(outcomes[0][0], LocalPath)
-    assert outcomes[0][0].basename == "dummy.ipynb"
+    assert isinstance(outcomes[0][0], Path)
+    assert outcomes[0][0].name == "dummy.ipynb"
     assert outcomes[0][1] == 0
     assert outcomes[0][2] == "notebook: nbregression(dummy)"
 


### PR DESCRIPTION
## About
Just maintenance.

## References
- https://github.com/chrisjsewell/pytest-notebook/issues/73
