### PR TITLE
Renovate: Configure `:disableDependencyDashboard`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":disableDependencyDashboard",
     ":disableRateLimiting"
   ],
   "labels": [


### PR DESCRIPTION
## About
Disable the Renovate Dependency Dashboard.

- https://docs.renovatebot.com/configuration-options/#dependencydashboard
- https://docs.renovatebot.com/presets-default/#disabledependencydashboard

## References
- https://github.com/pyveci/pueblo/issues/207
