### PR TITLE
Project metadata: Stop using license identifiers for backward compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ optional-dependencies.develop = [
   "black[jupyter]<26",
   "mypy<2",
   "poethepoet<1",
-  "pyproject-fmt>=1.3,<3",
+  "pyproject-fmt<3",
   "ruff<0.15",
   "validate-pyproject<1",
 ]
@@ -131,7 +131,7 @@ optional-dependencies.test = [
   "pueblo[testing]",
 ]
 optional-dependencies.testing = [
-  "coverage~=7.3",
+  "coverage<7.4",
   "pytest<10",
   "pytest-cov<8",
   "pytest-env<2",


### PR DESCRIPTION
## About
Resolve a deprecation warning.
- GH-214

## References
- https://github.com/pypa/setuptools/issues/4903#issuecomment-2741522686