### PR TITLE
Testing: Fix `ValueError: Invalid frequency: S`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changes for pueblo
 
 ## Unreleased
+- Testing: Fixed `ValueError: Invalid frequency: S. Failed to parse with
+  error message: Did you mean s?`
 
 ## 2025-12-15 v0.0.13
 - nlp: Switched from `langchain` to `langchain-core`

--- a/pueblo/testing/dataframe.py
+++ b/pueblo/testing/dataframe.py
@@ -54,7 +54,7 @@ class DataFrameFactory:
         return makeMixedDataFrame()
 
     def make_dateindex(self) -> pd.DataFrame:
-        return makeTimeDataFrame(nper=self.rows, freq="S")
+        return makeTimeDataFrame(nper=self.rows, freq="s")
 
     @staticmethod
     def make_wide(rows: int = default_rows_count, columns: int = 99) -> pd.DataFrame:


### PR DESCRIPTION
Just maintenance, because a slot on the nightly validation runs went south.

-- https://github.com/pyveci/pueblo/actions/workflows/main.yml