### PR TITLE
CI: Add `ngr` test path to Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,5 +7,11 @@
   ],
   "labels": [
     "dependencies"
+  ],
+
+  // `ngr` test cases include quite a bunch of package descriptions.
+  // https://docs.renovatebot.com/configuration-options/#includepaths
+  "includePaths": [
+    "/tests/ngr/**",
   ]
 }


### PR DESCRIPTION
## Problem

We discovered that test coverage must become tighter, specifically in the area of the ngr test runner.

## References

- GH-224