### PR TITLE
ngr: Update to poethepoet 0.37 at `ngr-python-test-poethepoet`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Testing: Fixed `ValueError: Invalid frequency: S. Failed to parse with
   error message: Did you mean s?`
+- ngr: Updated to poethepoet 0.37 at `ngr-python-test-poethepoet`
 
 ## 2025-12-15 v0.0.13
 - nlp: Switched from `langchain` to `langchain-core`

--- a/tests/ngr/python-poethepoet/pyproject.toml
+++ b/tests/ngr/python-poethepoet/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   "pytest<8",
-  "poethepoet<0.25",
+  "poethepoet<0.38",
 ]
 
 [tool.poe.tasks]


### PR DESCRIPTION
## Problem

We discovered that executing poethepoet-based tests with ngr went south with poethepoet 0.38, so this patch should do no harm.

## References

- GH-224