### PR TITLE
ngr: Update to poethepoet 0.38 at `ngr-python-test-poethepoet`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 - Testing: Fixed `ValueError: Invalid frequency: S. Failed to parse with
   error message: Did you mean s?`
-- ngr: Updated to poethepoet 0.37 at `ngr-python-test-poethepoet`
+- ngr: Updated to poethepoet 0.38 at `ngr-python-test-poethepoet`
 
 ## 2025-12-15 v0.0.13
 - nlp: Switched from `langchain` to `langchain-core`

--- a/pueblo/ngr/runner.py
+++ b/pueblo/ngr/runner.py
@@ -580,7 +580,12 @@ class PythonRunner(RunnerBase):
             from poethepoet.config import PoeConfig
 
             config = PoeConfig()
-            config.load()
+            # poethepoet 0.38 is now primarily based on asyncio,
+            # but added the `load_sync` method to compensate.
+            if hasattr(config, "load_sync"):
+                config.load_sync()
+            else:
+                config.load()
             return [task for task in config.tasks.keys() if task and task[0] != "_"]
         except Exception as ex:  # pylint: disable=broad-except
             # this happens if there's no pyproject.toml present

--- a/tests/ngr/python-poethepoet/pyproject.toml
+++ b/tests/ngr/python-poethepoet/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   "pytest<8",
-  "poethepoet<0.38",
+  "poethepoet<0.39",
 ]
 
 [tool.poe.tasks]


### PR DESCRIPTION
## Problem

We discovered that executing poethepoet-based tests with ngr went south with poethepoet 0.38, so this patch might also initially fail CI here.

## References

- GH-224