### PR TITLE
CI: Adjust Renovate configuration about including test paths

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,6 +12,6 @@
   // `ngr` test cases include quite a bunch of package descriptions.
   // https://docs.renovatebot.com/configuration-options/#includepaths
   "includePaths": [
-    "/tests/ngr/**",
+    "**/tests/**",
   ]
 }


### PR DESCRIPTION
## About
The job run [# 865e75c8-17a2-4db8-b9d9-16bc97e57e31](https://developer.mend.io/github/pyveci/pueblo/-/job/865e75c8-17a2-4db8-b9d9-16bc97e57e31) revealed that Renovate apparently uses a default list of `ignorePaths`, probably coming from the `config:recommended` preset:

> Renovate's default ignore is `node_modules` and `bower_components` only. If you are extending from the popular `config:recommended` preset then it adds ignore patterns for `vendor`, `examples`, `test(s)` and `fixtures` directories too.
>
> -- https://docs.renovatebot.com/configuration-options/#ignorepaths

```json5
// DEBUG: Found repo ignorePaths
{
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ]
}
```

## References
- GH-224