### PR TITLE
Downgrade to `unstructured` v0.18.27 due to problems with `llvmlite`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes for pueblo
 
 ## Unreleased
+- Downgraded to `unstructured` v0.18.27 due to installation problems with `llvmlite`
 
 ## 2026-01-25 v0.0.14
 - Testing: Fixed `ValueError: Invalid frequency: S. Failed to parse with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ optional-dependencies.nlp = [
   "langchain-community<0.5",
   "langchain-core>=0.2,<1.3",
   "langchain-text-splitters<1.2",
-  "unstructured<0.19",
+  "unstructured<0.18.31",
 ]
 optional-dependencies.notebook = [
   "nbclient<0.11",


### PR DESCRIPTION
Just maintenance.