### PR TITLE
nlp: Relax package dependencies by removing upper bounds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - general: Downgrade to poethepoet 0.42 to fix task runner API
+- nlp: Relax package dependencies by removing upper bounds. The idea of a
+  "validated ecosystem" is counter-productive in this case, because the
+  strict constraints limit test case evolution.
 
 ## 2026-03-22 v0.0.17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,13 +100,13 @@ optional-dependencies.ngr = [
   "pueblo[cli]",
 ]
 optional-dependencies.nlp = [
-  "aiohttp<3.14",
-  "langchain-community<0.5",
-  "langchain-core>=0.2,<1.3",
-  "langchain-text-splitters<1.2",
-  "requests-cache<2",
-  "spacy<3.9",
-  "unstructured<0.22.7",
+  "aiohttp",
+  "langchain-community",
+  "langchain-core",
+  "langchain-text-splitters",
+  "requests-cache",
+  "spacy",
+  "unstructured",
 ]
 optional-dependencies.notebook = [
   "nbclient<0.11",


### PR DESCRIPTION
## About
The idea of a "validated ecosystem" is counter-productive in this case, because the strict constraints limit test case evolution.

## References
- https://github.com/pyveci/pueblo/pull/255
- https://github.com/pyveci/pueblo/actions/runs/23963584772