### PR TITLE
Adjust dependency specification for `click-aliases`, for Python 3.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- general: Adjusted dependency specification for `click-aliases`,
+  for compatibility with Python 3.8.
+
 ## 2026-04-07 v0.0.18
 
 - general: Downgrade to poethepoet 0.42 to fix task runner API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ optional-dependencies.all = [
 ]
 optional-dependencies.cli = [
   "click<9",
-  "click-aliases>=1.0.4,<2",
+  "click-aliases<=1.0.5; python_version<'3.10'",
+  "click-aliases>=1.0.6,<2; python_version>='3.10'",
   "colorlog<7",
   "python-dotenv<2",
 ]


### PR DESCRIPTION
Just maintenance.