### PR TITLE
nlp: Downgrade to unstructured 0.17

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - general: Adjusted dependency specification for `click-aliases`,
   for compatibility with Python 3.8.
+- nlp: Downgraded to unstructured 0.17, to get rid of the
+  transitive `llvmlite` and `numba` dependencies
 
 ## 2026-04-07 v0.0.18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ optional-dependencies.cli = [
 ]
 optional-dependencies.dataframe = [
   "dask",
-  "numba>=0.50",
   "numpy",
   "pandas",
   "pyarrow",
@@ -108,7 +107,7 @@ optional-dependencies.nlp = [
   "langchain-text-splitters",
   "requests-cache",
   "spacy",
-  "unstructured",
+  "unstructured<0.18",
 ]
 optional-dependencies.notebook = [
   "nbclient<0.12",


### PR DESCRIPTION
## About
The transitive `llvmlite` and `numba` dependencies sometimes cause build problems, so try to get rid of them.

## References
- GH-289
